### PR TITLE
프로그레스 바, 인풋, global.css 수정

### DIFF
--- a/client_dc/src/app/globals.css
+++ b/client_dc/src/app/globals.css
@@ -36,3 +36,7 @@
   font-family: 'NANUMSQUAREEB';
   src: url('../../public/font/NANUMSQUAREEB.OTF');
 }
+
+input[type='password'] {
+  font-family: 'Malgun gothic', dotum, sans-serif;
+}

--- a/client_dc/src/components/Input.tsx
+++ b/client_dc/src/components/Input.tsx
@@ -5,7 +5,7 @@
 type Props = {
   inputType: string;
   inputName?: string;
-  value: string;
+  value: string | number;
   placeholder?: string;
   hasBorder?: boolean;
   width?: string;

--- a/client_dc/src/components/ProgressBar.tsx
+++ b/client_dc/src/components/ProgressBar.tsx
@@ -9,14 +9,12 @@ type Props = {
 
 export default function ProgressBar({ progress = 0, width, height, displayPercentage }: Props) {
   const getBarColor = (progress: number) => {
-    if (progress < 34) return '--lightBlue';
-    else if (progress < 67) return '--orange';
-    else return '--primaryRed';
+    if (progress < 34) return '#85daff';
+    else if (progress < 67) return '#ffaa85';
+    else return '#ff8585';
   };
 
-  const barColorVarName = getBarColor(progress);
-  const rootStyles = getComputedStyle(document.documentElement);
-  const barColor = rootStyles.getPropertyValue(barColorVarName).trim();
+  const barColor = getBarColor(progress);
 
   const barStyle = {
     width: `${progress}%`,


### PR DESCRIPTION
## Issue
DREAM-10

## 구현 내용

- progress bar에서 computedStyle 관련 로직 삭제
- input value props 타입 변경
- global.css에 input type password 폰트 설정
