### PR TITLE
아이템 컴포넌트 구현

### DIFF
--- a/client_dc/public/image/index.ts
+++ b/client_dc/public/image/index.ts
@@ -10,3 +10,4 @@ export { default as refresh } from './refresh.svg';
 export { default as vercel } from './dashLine.svg';
 export { default as downArrowDark } from './downArrowDark.svg';
 export { default as arrowDown } from './arrowDown.svg';
+export { default as whiteDownArrow } from './whiteDownArrow.svg';

--- a/client_dc/src/components/Dropdown.tsx
+++ b/client_dc/src/components/Dropdown.tsx
@@ -2,17 +2,15 @@
 
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
-import DownArrow from '~/image/DownArrow.svg';
-import DarkDownArrow from '~/image/DarkDownArrow.svg';
-import WhiteDownArrow from '~/image/whiteDownArrow.svg';
+import { arrowDown, downArrowDark, whiteDownArrow } from '~/image';
 
 type Props = {
-  list: number[] | string[];
+  list: string[];
   prevIcon?: boolean;
   borderless?: boolean;
   filled?: boolean;
   width: string;
-  setState: React.Dispatch<React.SetStateAction<number | string>>;
+  setState: React.Dispatch<React.SetStateAction<string>>;
 };
 
 /** using example */
@@ -63,7 +61,7 @@ export default function Dropdown({ list, prevIcon, borderless, filled, width, se
 
   return (
     <div
-      className={`relative font-neb text-xs rounded-lg origin-top text-blue-primary ${
+      className={`relative bg-white font-neb text-xs rounded-lg origin-top text-blue-primary ${
         clickDropdown && 'rounded-b-none'
       } ${width && width} ${showShadow ? 'animate-show-shadow' : ''}`}
       onClick={() => setClickDropdown(!clickDropdown)}
@@ -76,7 +74,7 @@ export default function Dropdown({ list, prevIcon, borderless, filled, width, se
       >
         <div className='flex h-7 items-center justify-center'>{list[selectedIdx]}</div>
         <Image
-          src={filled ? WhiteDownArrow : clickDropdown ? DarkDownArrow : DownArrow}
+          src={filled ? whiteDownArrow : clickDropdown ? downArrowDark : arrowDown}
           className={`absolute top-1/2 -translate-y-1/2 ${prevIcon ? 'left-2' : 'right-2'}`}
           width={20}
           height={20}
@@ -87,7 +85,7 @@ export default function Dropdown({ list, prevIcon, borderless, filled, width, se
       <div
         className={`${showOptions ? 'block' : 'hidden'}  ${
           showShadow ? 'animate-show-shadow' : ''
-        } ${width && width} absolute z-30 border rounded-lg border-t-0 rounded-t-none origin-top ${
+        } w-full absolute z-30 border rounded-lg border-t-0 rounded-t-none origin-top ${
           filled ? 'bg-grey-text border-grey-text' : 'bg-white border-blue-primary'
         } ${clickDropdown ? 'animate-ease-down' : 'animate-ease-up'}`}
       >

--- a/client_dc/src/components/Item.tsx
+++ b/client_dc/src/components/Item.tsx
@@ -1,0 +1,27 @@
+import { ProgressBar } from '.';
+
+// 마이페이지 - 성공한 제품 리스트 { 제목, 성공날짜, 상품 금액 }
+// 휴지통 - 삭제된 제품 리스트 { 제목, 삭제날짜, 진행률(혹은 상품금액과 입금금액) }
+
+// TODO: 클릭시 상세페이지로 이동
+// TODO: 휴지통에서 편집 클릭시 왼쪽에 체크박스 표시되어야 함
+
+export default function Item() {
+  return (
+    <div className='flex items-center border-b border-grey-border px-2 pt-5 pb-3'>
+      {/* TODO: EDIT 모드 실행시 체크박스 노출 부분 */}
+      {/* <input type='checkbox' className='mr-3' /> */}
+      <div className='min-w-0'>
+        <div className='flex justify-between items-center pb-2 px-1 gap-2'>
+          <h2 className='font-nb text-grey-text whitespace-nowrap text-ellipsis overflow-hidden'>
+            넥스트를 정복하기위한 파란만장 프로젝트
+          </h2>
+          <span className='font-nr text-xs text-grey-border w-fit whitespace-nowrap text-end'>
+            삭제날짜 2023.08.30
+          </span>
+        </div>
+        <ProgressBar progress={100} displayText price={100000} />
+      </div>
+    </div>
+  );
+}

--- a/client_dc/src/components/Item.tsx
+++ b/client_dc/src/components/Item.tsx
@@ -1,26 +1,46 @@
+'use client';
+
 import { ProgressBar } from '.';
+import { usePathname, useRouter } from 'next/navigation';
 
-// 마이페이지 - 성공한 제품 리스트 { 제목, 성공날짜, 상품 금액 }
-// 휴지통 - 삭제된 제품 리스트 { 제목, 삭제날짜, 진행률(혹은 상품금액과 입금금액) }
-
-// TODO: 클릭시 상세페이지로 이동
 // TODO: 휴지통에서 편집 클릭시 왼쪽에 체크박스 표시되어야 함
 
-export default function Item() {
+type Props = {
+  itemId: number;
+  title: string;
+  date: string;
+  groupPurchase: boolean;
+  progress?: number;
+  price?: number;
+};
+
+export default function Item({ itemId, title, date, groupPurchase, progress, price }: Props) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const isMyPage = pathname.startsWith('/user');
+
+  const handleClick = () => {
+    if (!isMyPage) return;
+    router.push(`/detail/${groupPurchase ? 'group' : 'solo'}/${itemId}`);
+  };
+
   return (
-    <div className='flex items-center border-b border-grey-border px-2 pt-5 pb-3'>
+    <div
+      className='flex items-center border-b border-grey-border px-2 pt-5 pb-3'
+      onClick={handleClick}
+    >
       {/* TODO: EDIT 모드 실행시 체크박스 노출 부분 */}
       {/* <input type='checkbox' className='mr-3' /> */}
-      <div className='min-w-0'>
+      <div className='min-w-0 w-full'>
         <div className='flex justify-between items-center pb-2 px-1 gap-2'>
           <h2 className='font-nb text-grey-text whitespace-nowrap text-ellipsis overflow-hidden'>
-            넥스트를 정복하기위한 파란만장 프로젝트
+            {title}
           </h2>
           <span className='font-nr text-xs text-grey-border w-fit whitespace-nowrap text-end'>
-            삭제날짜 2023.08.30
+            {isMyPage ? '성공' : '삭제'}날짜 {date}
           </span>
         </div>
-        <ProgressBar progress={100} displayText price={100000} />
+        <ProgressBar progress={progress ?? 100} displayText price={price} />
       </div>
     </div>
   );

--- a/client_dc/src/components/ProgressBar.tsx
+++ b/client_dc/src/components/ProgressBar.tsx
@@ -4,10 +4,11 @@ type Props = {
   progress: number;
   width?: string;
   height?: string;
-  displayPercentage?: boolean;
+  displayText?: boolean;
+  price?: number;
 };
 
-export default function ProgressBar({ progress = 0, width, height, displayPercentage }: Props) {
+export default function ProgressBar({ progress = 0, width, height, displayText, price }: Props) {
   const getBarColor = (progress: number) => {
     if (progress < 34) return '#85daff';
     else if (progress < 67) return '#ffaa85';
@@ -30,13 +31,13 @@ export default function ProgressBar({ progress = 0, width, height, displayPercen
       }`}
     >
       <div className='h-full rounded-full' style={barStyle}></div>
-      {displayPercentage && (
+      {displayText && (
         <div
           className={`absolute inset-0 flex items-center justify-center text-sm font-medium ${
             progress >= 60 ? 'text-white' : 'text-grey-text'
           }`}
         >
-          {progress}%
+          {price ? `${price.toLocaleString()}원` : `${progress}%`}
         </div>
       )}
     </div>

--- a/client_dc/src/components/index.ts
+++ b/client_dc/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as Input } from './Input';
 export { default as NavBar } from './NavBar';
 export { default as ProgressBar } from './ProgressBar';
 export { default as Tag } from './Tag';
+export { default as Item } from './Item';


### PR DESCRIPTION
## Issue
DREAM-15

## 구현 내용
마이페이지, 휴지통에 쓰이는 아이템 컴포넌트 구현

## 구현  화면
![스크린샷 2023-09-22 오후 4 45 28](https://github.com/KimJunpyo/DreamConsumer/assets/107546528/280636e3-4104-4429-ba2d-e397e99e96ac)

## 참고 사항
- 휴지통에서 아이템 클릭시 아무 동작도 하지 않고 마이페이지에서 클릭시 상세페이지로 이동함
- price를 props로 내릴 경우 progress 대신 금액이 렌더링됨